### PR TITLE
Tony

### DIFF
--- a/src/Java/Controllers/MapController.java
+++ b/src/Java/Controllers/MapController.java
@@ -71,7 +71,7 @@ public class MapController implements Initializable {
         muleGame.setPrice();
         if (!muleGame.selectionRound) {
             //skipButton.setVisible(false);
-            String playerColor = muleGame.getPlayers()[muleGame.getCurrentPlayer()].getColor();
+            String playerColor = muleGame.getCurrentPlayerObject().getColor();
             bottomBar.setStyle("-fx-background-color: " + playerColor);
 
         } else {
@@ -102,27 +102,27 @@ public class MapController implements Initializable {
                 button.setOnMouseClicked(new EventHandler<MouseEvent>() {
                     @Override
                     public void handle(MouseEvent event) {
-                        if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null
+                        if (muleGame.getCurrentPlayerObject().getMuleInHand() != null
                                 && !button.getTile().isOwned()) {
                             System.out.println("you lost that mule, dummie. tile not owned");
                             stage.getScene().setCursor(Cursor.DEFAULT);
-                            muleGame.getPlayers()[muleGame.getCurrentPlayer()].setMuleInHand(null);
-                        } else if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null
+                            muleGame.getCurrentPlayerObject().setMuleInHand(null);
+                        } else if (muleGame.getCurrentPlayerObject().getMuleInHand() != null
                                 && button.getTile().getMule() != null){
                             System.out.println("You lost that mule, dummie. already has a mule");
                             stage.getScene().setCursor(Cursor.DEFAULT);
-                            muleGame.getPlayers()[muleGame.getCurrentPlayer()].setMuleInHand(null);
-                        } else if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null
+                            muleGame.getCurrentPlayerObject().setMuleInHand(null);
+                        } else if (muleGame.getCurrentPlayerObject().getMuleInHand() != null
                                 && !(button.getId().equals("t"))) {
-                            if (button.getTile().getOwner().equals(muleGame.getPlayers()[muleGame.getCurrentPlayer()])) {
+                            if (button.getTile().getOwner().equals(muleGame.getCurrentPlayerObject())) {
                                 System.out.println("CORRECT OWNER");
                                 button.setText("M U              L E");
-                                button.getTile().setMule(muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand());
+                                button.getTile().setMule(muleGame.getCurrentPlayerObject().getMuleInHand());
                             } else {
                                 System.out.println("You lost that mule, dummie");
                             }
                             stage.getScene().setCursor(Cursor.DEFAULT);
-                            muleGame.getPlayers()[muleGame.getCurrentPlayer()].setMuleInHand(null);
+                            muleGame.getCurrentPlayerObject().setMuleInHand(null);
                         } else {
                             if (button.getId().equals("t")) {
                                 if (!muleGame.selectionRound) {
@@ -156,7 +156,7 @@ public class MapController implements Initializable {
 //                            if (muleGame.selectionRound) {
 //                                muleGame.setPrice(muleGame.getRound(), muleGame.getPlayers()[selectingPlayer]);
 //                            } else {
-//                                muleGame.setPrice(muleGame.getRound(), muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+//                                muleGame.setPrice(muleGame.getRound(), muleGame.getCurrentPlayerObject());
 //                            }
                                 accept.setText("Accept");
                                 Button decline = new Button();
@@ -209,9 +209,9 @@ public class MapController implements Initializable {
                                                 vbox.getChildren().setAll(accept, decline, failText);
                                             }
                                         } else {
-                                            //muleGame.setPrice(muleGame.getRound(), muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
-                                            if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney() >= currentPrice) {
-                                                purchaseLand(muleGame.getPlayers()[muleGame.getCurrentPlayer()], button, muleGame.selectionRound);
+                                            //muleGame.setPrice(muleGame.getRound(), muleGame.getCurrentPlayerObject());
+                                            if (muleGame.getCurrentPlayerObject().getMoney() >= currentPrice) {
+                                                purchaseLand(muleGame.getCurrentPlayerObject(), button, muleGame.selectionRound);
                                             } else {
                                                 TextField failText = new TextField();
                                                 failText.setText("Not enough Money!");
@@ -242,8 +242,8 @@ public class MapController implements Initializable {
             currentPlayerLabel.setText("LS: " + muleGame.getPlayers()[selectingPlayer].getName()
                     + " Money Remaining: " + muleGame.getPlayers()[selectingPlayer].getMoney());
         } else {
-            currentPlayerLabel.setText("TURN: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getName()
-                    + " Money Remaining: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+            currentPlayerLabel.setText("TURN: " + muleGame.getCurrentPlayerObject().getName()
+                    + " Money Remaining: " + muleGame.getCurrentPlayerObject().getMoney());
             if (startOfTurn) {
                 startTimer(muleGame.getTimeForTurn());
             }
@@ -399,8 +399,8 @@ public class MapController implements Initializable {
             String color = player.getColor();
             button.setStyle("-fx-background-color: " + color);
             player.setMoney(player.getMoney() - currentPrice);
-            currentPlayerLabel.setText("TURN: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getName()
-                    + " Money Remaining: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+            currentPlayerLabel.setText("TURN: " + muleGame.getCurrentPlayerObject().getName()
+                    + " Money Remaining: " + muleGame.getCurrentPlayerObject().getMoney());
 
         }
 

--- a/src/Java/Controllers/PubController.java
+++ b/src/Java/Controllers/PubController.java
@@ -52,7 +52,7 @@ public class PubController implements Initializable{
                 Pub p = new Pub();
                 System.out.println(muleGame.timeRemaining);
                 int bonus = p.gamble(muleGame.timeRemaining, muleGame.getRound());
-                muleGame.getPlayers()[muleGame.getCurrentPlayer()].addMoney(bonus);
+                muleGame.getCurrentPlayerObject().addMoney(bonus);
                 System.out.println("Gambled for: " + bonus);
                 try {
                     FXMLLoader loader = new FXMLLoader();

--- a/src/Java/Controllers/RoundController.java
+++ b/src/Java/Controllers/RoundController.java
@@ -130,15 +130,15 @@ public class RoundController implements Initializable {
         RandomEventGenerator events = new RandomEventGenerator();
         boolean isLastPlace;
         if (!muleGame.selectionRound) {
-            System.out.println("It is " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].toString() + "'s turn!");
+            System.out.println("It is " + muleGame.getCurrentPlayerObject().toString() + "'s turn!");
             if (muleGame.getCurrentPlayer() == 0) {
                 isLastPlace = true;
             } else {
                 isLastPlace = false;
             }
-            System.out.println(events.getRandomEvent(muleGame.getPlayers()[muleGame.getCurrentPlayer()], isLastPlace));
-            muleGame.setTimeForTurn(muleGame.getPlayers()[muleGame.getCurrentPlayer()].calculateTimeForTurn(muleGame.getRound()));
-            nextAction.setText("TURN: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].toString()
+            System.out.println(events.getRandomEvent(muleGame.getCurrentPlayerObject(), isLastPlace));
+            muleGame.setTimeForTurn(muleGame.getCurrentPlayerObject().calculateTimeForTurn(muleGame.getRound()));
+            nextAction.setText("TURN: " + muleGame.getCurrentPlayerObject().toString()
                     + "\nTIME FOR TURN: " + muleGame.getTimeForTurn());
         } else {
             System.out.println("Next is a land selection");

--- a/src/Java/Controllers/StoreController.java
+++ b/src/Java/Controllers/StoreController.java
@@ -133,8 +133,8 @@ public class StoreController implements Initializable {
         sell_energy_button.setText("Price: 12");
         sell_food_button.setText("Price: 15");
         sell_smithore_button.setText("Price: 25");
-        player_Name.setText(muleGame.getPlayers()[muleGame.getCurrentPlayer()].getName());
-        player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+        player_Name.setText(muleGame.getCurrentPlayerObject().getName());
+        player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
 
         store_crystite_stock_label.setText("Stock: " + muleGame.getStore().getCrystiteStock());
         store_energy_stock_label.setText("Stock: " + muleGame.getStore().getEnergyStock());
@@ -143,10 +143,10 @@ public class StoreController implements Initializable {
         store_ore_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
         store_energy_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
         store_food_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
-        player_ore_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getOre());
-        player_energy_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getEnergy());
-        player_crystite_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getCrystite());
-        player_food_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getFood());
+        player_ore_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getOre());
+        player_energy_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getEnergy());
+        player_crystite_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getCrystite());
+        player_food_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getFood());
 //        food_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
 //            @Override
 //            public void handle(MouseEvent event) {
@@ -158,92 +158,92 @@ public class StoreController implements Initializable {
         buy_smithore_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyOre(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().buyOre(muleGame.getCurrentPlayerObject());
                 store_ore_stock_label.setText("Stock: " + muleGame.getStore().getOreStock());
-                player_ore_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getOre());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_ore_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getOre());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         sell_smithore_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().sellOre(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().sellOre(muleGame.getCurrentPlayerObject());
                 store_ore_stock_label.setText("Stock: " + muleGame.getStore().getOreStock());
-                player_ore_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getOre());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_ore_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getOre());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         buy_crystite_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyCrystite(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().buyCrystite(muleGame.getCurrentPlayerObject());
                 store_crystite_stock_label.setText("Stock: " + muleGame.getStore().getCrystiteStock());
-                player_crystite_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getCrystite());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_crystite_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getCrystite());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         sell_crystite_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().sellCrystite(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().sellCrystite(muleGame.getCurrentPlayerObject());
                 store_crystite_stock_label.setText("Stock: " + muleGame.getStore().getCrystiteStock());
-                player_crystite_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getCrystite());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_crystite_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getCrystite());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         buy_food_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyFood(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().buyFood(muleGame.getCurrentPlayerObject());
                 store_food_stock_label.setText("Stock: " + muleGame.getStore().getFoodStock());
-                player_food_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getFood());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_food_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getFood());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         sell_food_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().sellFood(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().sellFood(muleGame.getCurrentPlayerObject());
                 store_food_stock_label.setText("Stock: " + muleGame.getStore().getFoodStock());
-                player_food_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getFood());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_food_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getFood());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         buy_energy_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyEnergy(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().buyEnergy(muleGame.getCurrentPlayerObject());
                 store_energy_stock_label.setText("Stock: " + muleGame.getStore().getEnergyStock());
-                player_energy_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getEnergy());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_energy_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getEnergy());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         sell_energy_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().sellEnergy(muleGame.getPlayers()[muleGame.getCurrentPlayer()]);
+                muleGame.getStore().sellEnergy(muleGame.getCurrentPlayerObject());
                 store_energy_stock_label.setText("Stock: " + muleGame.getStore().getEnergyStock());
-                player_energy_stock_label.setText("Owned: " + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getEnergy());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
+                player_energy_stock_label.setText("Owned: " + muleGame.getCurrentPlayerObject().getEnergy());
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
             }
         });
 
         buy_energy_mule_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyMule(muleGame.getPlayers()[muleGame.getCurrentPlayer()], "energy", 150);
+                muleGame.getStore().buyMule(muleGame.getCurrentPlayerObject(), "energy", 150);
                 store_ore_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_energy_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_food_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
-                if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null) {
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
+                if (muleGame.getCurrentPlayerObject().getMuleInHand() != null) {
                     Image energyMule = new Image("/images/energyCursor.png");
                     stage.getScene().setCursor(new ImageCursor(energyMule));
                     Event.fireEvent(map_menu_button, new MouseEvent(MouseEvent.MOUSE_CLICKED,
@@ -256,12 +256,12 @@ public class StoreController implements Initializable {
         buy_ore_mule_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyMule(muleGame.getPlayers()[muleGame.getCurrentPlayer()], "ore", 175);
+                muleGame.getStore().buyMule(muleGame.getCurrentPlayerObject(), "ore", 175);
                 store_ore_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_energy_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_food_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
-                if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null) {
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
+                if (muleGame.getCurrentPlayerObject().getMuleInHand() != null) {
                     Image oreMule = new Image("/images/oreCursor.png");
                     stage.getScene().setCursor(new ImageCursor(oreMule));
                     Event.fireEvent(map_menu_button, new MouseEvent(MouseEvent.MOUSE_CLICKED,
@@ -274,12 +274,12 @@ public class StoreController implements Initializable {
         buy_food_mule_button.setOnMouseClicked(new EventHandler<MouseEvent>() {
             @Override
             public void handle(MouseEvent event) {
-                muleGame.getStore().buyMule(muleGame.getPlayers()[muleGame.getCurrentPlayer()], "food", 125);
+                muleGame.getStore().buyMule(muleGame.getCurrentPlayerObject(), "food", 125);
                 store_ore_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_energy_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
                 store_food_mule_stock_label.setText("Stock: " + muleGame.getStore().getMuleStock());
-                player_Money.setText("$" + muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMoney());
-                if (muleGame.getPlayers()[muleGame.getCurrentPlayer()].getMuleInHand() != null) {
+                player_Money.setText("$" + muleGame.getCurrentPlayerObject().getMoney());
+                if (muleGame.getCurrentPlayerObject().getMuleInHand() != null) {
                     Image foodMule = new Image("/images/foodCursor.gif");
                     stage.getScene().setCursor(new ImageCursor(foodMule));
                     Event.fireEvent(map_menu_button, new MouseEvent(MouseEvent.MOUSE_CLICKED,

--- a/src/Java/Objects/MuleGame.java
+++ b/src/Java/Objects/MuleGame.java
@@ -145,6 +145,8 @@ public class MuleGame {
         currentPlayer++;
     }
 
+    public Player getCurrentPlayerObject() { return players[currentPlayer]; }
+
     public void setCurrentPlayer(int currentPlayer) {
         this.currentPlayer = currentPlayer;
     }


### PR DESCRIPTION
Made it so MuleGame has a direct reference to the actual current player
so we don’t have to pull that
muleGame.getPlayers[muleGame.getCurrentPlayer()] thing anymore. The
muleGame.getCurrentPlayer() method still returns the int where the
player is in the order, getCurrentPlayerObject() is the new method that
returns the actual Player object
